### PR TITLE
Np 1794 bibsys feide

### DIFF
--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
@@ -60,7 +60,7 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
     @Override
     public Map<String, Object> handleRequest(Map<String, Object> input, Context context) {
 
-        logger.debug("handler input={}",input);
+        logger.info("handler input={}",input);
 
         Event event = parseEventFromInput(input);
 

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
@@ -52,7 +52,7 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
     public static final int START_OF_STRING = 0;
     private static final Logger logger = LoggerFactory.getLogger(PostAuthenticationHandler.class);
     public static final String TRAILING_BRACKET = "]";
-    public static final char NABLA = '@';
+    public static final char AFFILIATION_PART_SEPARATOR = '@';
     public static final String COMMA_SPACE = ", ";
     public static final String COMMA = ",";
     public static final String APPLICATION_ROLES_MESSAGE = "applicationRoles: ";
@@ -233,8 +233,8 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
     }
 
     private String extractAffiliation(String hostedAffiliation) {
-        if (!isEmpty(hostedAffiliation) && hostedAffiliation.contains(String.valueOf(NABLA)))  {
-            return hostedAffiliation.substring(START_OF_STRING, hostedAffiliation.indexOf(NABLA));
+        if (!isEmpty(hostedAffiliation) && hostedAffiliation.contains(String.valueOf(AFFILIATION_PART_SEPARATOR)))  {
+            return hostedAffiliation.substring(START_OF_STRING, hostedAffiliation.indexOf(AFFILIATION_PART_SEPARATOR));
         } else {
             return EMPTY_STRING;
         }

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
@@ -60,6 +60,8 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
     @Override
     public Map<String, Object> handleRequest(Map<String, Object> input, Context context) {
 
+        logger.debug("handler input={}",input);
+
         Event event = parseEventFromInput(input);
 
         String userPoolId = event.getUserPoolId();

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
@@ -70,6 +70,8 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
         UserAttributes userAttributes = event.getRequest().getUserAttributes();
 
         if (userIsBibsysHosted(userAttributes)) {
+            logger.info("Overriding orgNumber({}) with hostedOrgNumber({})",
+                    userAttributes.getOrgNumber(), userAttributes.getHostedOrgNumber());
             userAttributes.setOrgNumber(userAttributes.getHostedOrgNumber());
         }
         String orgNumber = userAttributes.getOrgNumber();
@@ -204,7 +206,9 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
     }
 
     private boolean userIsBibsysHosted(UserAttributes userAttributes) {
-        return userAttributes.getFeideId().endsWith(BIBSYS_HOST)
+        boolean isHosted = userAttributes.getFeideId().endsWith(BIBSYS_HOST)
                 && Objects.nonNull(userAttributes.getHostedOrgNumber());
+        logger.info("User {} isHosted={}", userAttributes, isHosted);
+        return  isHosted;
     }
 }

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/PostAuthenticationHandler.java
@@ -69,12 +69,10 @@ public class PostAuthenticationHandler implements RequestHandler<Map<String, Obj
 
         UserAttributes userAttributes = event.getRequest().getUserAttributes();
 
-        String orgNumber;
-        if(userIsBibsysHosted(userAttributes)) {
-            orgNumber = userAttributes.getHostedOrgNumber();
-        } else {
-           orgNumber = userAttributes.getOrgNumber();
+        if (userIsBibsysHosted(userAttributes)) {
+            userAttributes.setOrgNumber(userAttributes.getHostedOrgNumber());
         }
+        String orgNumber = userAttributes.getOrgNumber();
         Optional<CustomerResponse> customer = mapOrgNumberToCustomer(removeCountryPrefix(orgNumber));
         Optional<String> customerId = customer.map(CustomerResponse::getCustomerId);
         Optional<String> cristinId = customer.map(CustomerResponse::getCristinId);

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/model/UserAttributes.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/model/UserAttributes.java
@@ -19,6 +19,12 @@ public class UserAttributes {
     @JsonProperty("family_name")
     private String familyName;
 
+    @JsonProperty("custom:hostedOrgNumber")
+    private String hostedOrgNumber;
+
+    @JsonProperty("custom:hostedAffiliation")
+    private String hostedAffiliation;
+
     public String getFeideId() {
         return feideId;
     }
@@ -57,5 +63,21 @@ public class UserAttributes {
 
     public void setFamilyName(String familyName) {
         this.familyName = familyName;
+    }
+
+    public String getHostedOrgNumber() {
+        return hostedOrgNumber;
+    }
+
+    public void setHostedOrgNumber(String hostedOrgNumber) {
+        this.hostedOrgNumber = hostedOrgNumber;
+    }
+
+    public String getHostedAffiliation() {
+        return hostedAffiliation;
+    }
+
+    public void setHostedAffiliation(String hostedAffiliation) {
+        this.hostedAffiliation = hostedAffiliation;
     }
 }


### PR DESCRIPTION
Handling Bibsys hosted feide user, overriding orgNumber and affiliation in UserDTO to get custom:accessRights and 	custom:customerId right. Does not write overridden fields back to Cognito.